### PR TITLE
nignxが起動できない問題を修正する

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -10,7 +10,7 @@ server {
 
     location ~ \.php$ {
         root           /var/www/html/public;
-        fastcgi_pass   php-fpm:9000;
+        fastcgi_pass   web:9000;
         fastcgi_index  index.php;
         fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
         include        fastcgi_params;


### PR DESCRIPTION
## 関連リンク
* https://github.com/seakun00/Chat/pull/1

## 概要
nignxの起動で以下のエラーが表示される。

```
[emerg] 1#1: host not found in upstream "php-fpm" in /etc/nginx/conf.d/default.conf:13
```

## 原因
dockerのサービス名を変更した際に、nignxの設定ファイルを変更できていなかった。

## テスト
* [x] nignxが起動できる